### PR TITLE
Fixed typo in index.html

### DIFF
--- a/doc/html/index.html
+++ b/doc/html/index.html
@@ -262,7 +262,7 @@
             <div class="col-md-9" role="main">
 
 <h1 id="overview">Overview</h1>
-<p>Fit is an header-only C++11 library that provides utilities for functions and function objects. Fit is divided into three components:</p>
+<p>Fit is a header-only C++11 library that provides utilities for functions and function objects. Fit is divided into three components:</p>
 <ul>
 <li>Function Adaptors: These take functions and return a new function that provides an additional capability to the previous function.</li>
 <li>Functions: These return functions that acheive a specific purpose.</li>


### PR DESCRIPTION
"Fit is _a_ header-only library", not "an"
