### PR TITLE
FIX(BUILD): Compilation with GCC on Apple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set (Fit_VERSION_MINOR 3)
 include(CheckCXXCompilerFlag)
 enable_language(CXX)
 
-if(CMAKE_HOST_APPLE)
+if(CMAKE_HOST_APPLE AND (NOT CMAKE_COMPILER_IS_GNUCXX))
     list(APPEND CXX_EXTRA_FLAGS -stdlib=libc++)
 endif()
 


### PR DESCRIPTION
I got error `g++-5: error: unrecognized command line option '-stdlib=libc++'` when compiling tests on Apple with GNU GCC.

I added a test inside CMakeLists.txt to only add `stdlib=libc++` compilation flags when on Apple but not when using GNU GCC: (NOT CMAKE_COMPILER_IS_GNUCXX)