### PR TITLE
Fix typo in docs for conditional.hpp

### DIFF
--- a/include/fit/conditional.hpp
+++ b/include/fit/conditional.hpp
@@ -51,7 +51,7 @@
 /// 
 ///     struct for_floats
 ///     {
-///         void operator()(int) const
+///         void operator()(float) const
 ///         {
 ///             printf("Float\n");
 ///         }


### PR DESCRIPTION
I believe this is a typo right? My colleague noticed it while showing me the library.