### PR TITLE
Docs: In combine() docs, use different int constants for clarity.

### DIFF
--- a/include/fit/combine.hpp
+++ b/include/fit/combine.hpp
@@ -44,7 +44,7 @@
 ///         fit::construct<std::tuple>(),
 ///         fit::capture(1)(fit::construct<std::pair>()),
 ///         fit::capture(2)(fit::construct<std::pair>()));
-///     assert(f(2, 4) == std::make_tuple(std::make_pair(1, 2), std::make_pair(2, 4)));
+///     assert(f(3, 7) == std::make_tuple(std::make_pair(1, 3), std::make_pair(2, 7)));
 /// 
 
 #include <fit/pack.hpp>


### PR DESCRIPTION
When I jumped straight to the code on first reading the sample, I mistakenly thought that the pairs (1, 2) and (2, 4) were pairwise related by "times 2".  Using different constants removes this possibility.