### PR TITLE
substitute combinator

### DIFF
--- a/include/boost/hof.hpp
+++ b/include/boost/hof.hpp
@@ -52,6 +52,7 @@
 #include <boost/hof/reverse_fold.hpp>
 #include <boost/hof/rotate.hpp>
 #include <boost/hof/static.hpp>
+#include <boost/hof/substitute.hpp>
 #include <boost/hof/tap.hpp>
 #include <boost/hof/unpack.hpp>
 

--- a/include/boost/hof/substitute.hpp
+++ b/include/boost/hof/substitute.hpp
@@ -129,7 +129,6 @@ struct substitute_adaptor<F> : detail::callable_base<F>
     BOOST_HOF_NOEXCEPT_CONSTRUCTIBLE(detail::callable_base<F>, X&&)
     : detail::callable_base<F>(BOOST_HOF_FORWARD(X)(f1))
     {}
-
 };
 
 template<class F1, class F2>

--- a/include/boost/hof/substitute.hpp
+++ b/include/boost/hof/substitute.hpp
@@ -1,0 +1,149 @@
+/*=============================================================================
+    Copyright (c) 2014 Paul Fultz II
+    substitute.h
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+
+#ifndef BOOST_HOF_GUARD_FUNCTION_SUBSTITUTE_H
+#define BOOST_HOF_GUARD_FUNCTION_SUBSTITUTE_H
+
+/// substitute
+/// =======
+/// 
+/// Description
+/// -----------
+/// 
+/// The `substitute` function adaptor provides substituted composition. This
+/// combinator evaluates a set of functions with the same inputs arguments, and
+/// then applies composition. So, `substitute(f, g)(x) == f(x)(g(x))`.
+/// 
+/// 
+/// Synopsis
+/// --------
+/// 
+///     template<class... Fs>
+///     constexpr substitute_adaptor<Fs...> substitute(Fs... fs);
+/// 
+/// Semantics
+/// ---------
+/// 
+///     assert(substitute(f, g)(xs...) == f(xs...)(g(xs...)));
+/// 
+/// Requirements
+/// ------------
+/// 
+/// Fs must be:
+/// 
+/// * [ConstInvocable](ConstInvocable)
+/// * MoveConstructible
+/// 
+/// Example
+/// -------
+/// 
+///     #include <boost/hof.hpp>
+///     #include <cassert>
+///     using namespace boost::hof;
+/// 
+///     int main() {
+///         int r = substitute(always, always)(3);
+///         assert(r == 3);
+///     }
+/// 
+/// References
+/// ----------
+/// 
+/// * [Substitution combinator](https://en.wikipedia.org/wiki/Combinatory_logic#Examples_of_combinators)
+/// 
+/// 
+
+#include <boost/hof/detail/callable_base.hpp>
+// #include <boost/hof/always.hpp>
+#include <boost/hof/detail/delegate.hpp>
+#include <boost/hof/detail/compressed_pair.hpp>
+#include <boost/hof/detail/join.hpp>
+#include <tuple>
+#include <boost/hof/detail/move.hpp>
+#include <boost/hof/detail/make.hpp>
+#include <boost/hof/detail/result_type.hpp>
+#include <boost/hof/detail/static_const_var.hpp>
+
+namespace boost { namespace hof { namespace detail {
+
+template<class F1, class F2>
+struct substitute_kernel : detail::compressed_pair<F1, F2>
+                         // , compose_function_result_type<F1, F2>
+{
+    typedef detail::compressed_pair<F1, F2> base_type;
+
+    BOOST_HOF_INHERIT_CONSTRUCTOR(substitute_kernel, base_type)
+
+    BOOST_HOF_RETURNS_CLASS(substitute_kernel);
+
+    template<class... Ts>
+    constexpr BOOST_HOF_SFINAE_RESULT(const F1&, result_of<const F2&, id_<Ts>...>)
+    operator()(Ts&&... xs) const BOOST_HOF_SFINAE_RETURNS
+    (
+        BOOST_HOF_MANGLE_CAST(const F1&)(BOOST_HOF_CONST_THIS->first(xs...))(BOOST_HOF_FORWARD(Ts)(xs)...)(
+            BOOST_HOF_MANGLE_CAST(const F2&)(BOOST_HOF_CONST_THIS->second(xs...))(BOOST_HOF_FORWARD(Ts)(xs)...)
+        )
+    );
+};
+}
+
+template<class F, class... Fs>
+struct substitute_adaptor 
+: detail::substitute_kernel<detail::callable_base<F>, BOOST_HOF_JOIN(substitute_adaptor, detail::callable_base<Fs>...)>
+{
+    typedef substitute_adaptor fit_rewritable_tag;
+    typedef BOOST_HOF_JOIN(substitute_adaptor, detail::callable_base<Fs>...) tail;
+    typedef detail::substitute_kernel<detail::callable_base<F>, tail> base_type;
+
+    BOOST_HOF_INHERIT_DEFAULT(substitute_adaptor, base_type)
+
+    template<class X, class... Xs,
+        BOOST_HOF_ENABLE_IF_CONSTRUCTIBLE(detail::callable_base<F>, X),
+        BOOST_HOF_ENABLE_IF_CONSTRUCTIBLE(tail, Xs...)
+    >
+    constexpr substitute_adaptor(X&& f1, Xs&& ... fs)
+    BOOST_HOF_NOEXCEPT(BOOST_HOF_IS_NOTHROW_CONSTRUCTIBLE(base_type, X&&, tail) && BOOST_HOF_IS_NOTHROW_CONSTRUCTIBLE(tail, Xs&&...))
+    : base_type(BOOST_HOF_FORWARD(X)(f1), tail(BOOST_HOF_FORWARD(Xs)(fs)...))
+    {}
+
+    template<class X, BOOST_HOF_ENABLE_IF_CONSTRUCTIBLE(detail::callable_base<F>, X)>
+    constexpr substitute_adaptor(X&& f1) 
+    BOOST_HOF_NOEXCEPT_CONSTRUCTIBLE(base_type, X&&)
+    : base_type(BOOST_HOF_FORWARD(X)(f1))
+    {}
+};
+
+template<class F>
+struct substitute_adaptor<F> : detail::callable_base<F>
+{
+    typedef substitute_adaptor fit_rewritable_tag;
+
+    BOOST_HOF_INHERIT_DEFAULT(substitute_adaptor, detail::callable_base<F>)
+
+    template<class X, BOOST_HOF_ENABLE_IF_CONVERTIBLE(X, detail::callable_base<F>)>
+    constexpr substitute_adaptor(X&& f1)
+    BOOST_HOF_NOEXCEPT_CONSTRUCTIBLE(detail::callable_base<F>, X&&)
+    : detail::callable_base<F>(BOOST_HOF_FORWARD(X)(f1))
+    {}
+
+};
+
+template<class F1, class F2>
+struct substitute_adaptor<F1, F2>
+: detail::substitute_kernel<detail::callable_base<F1>, detail::callable_base<F2>>
+{
+    typedef substitute_adaptor fit_rewritable_tag;
+    typedef detail::substitute_kernel<detail::callable_base<F1>, detail::callable_base<F2>> base_type;
+
+    BOOST_HOF_INHERIT_CONSTRUCTOR(substitute_adaptor, base_type)
+};
+
+BOOST_HOF_DECLARE_STATIC_VAR(substitute, detail::make<substitute_adaptor>);
+
+}} // namespace boost::hof
+
+#endif

--- a/test/substitute.cpp
+++ b/test/substitute.cpp
@@ -15,7 +15,7 @@ struct fx_x_add_n {
     int n;
     constexpr fx_x_add_n(int n) : n(n) {}
     template<class T>
-    constexpr T operator()(T x) const
+    constexpr T operator()(T x) const noexcept
     {
         return x + n;
     }
@@ -25,7 +25,7 @@ struct fx_x_times_n {
     int n;
     constexpr fx_x_times_n(int n) : n(n) {}
     template<class T>
-    constexpr T operator()(T x) const
+    constexpr T operator()(T x) const noexcept
     {
         return x * n;
     }
@@ -35,7 +35,7 @@ struct fx_n_sub_x {
     int n;
     constexpr fx_n_sub_x(int n) : n(n) {}
     template<class T>
-    constexpr T operator()(T x) const
+    constexpr T operator()(T x) const noexcept
     {
         return n - x;
     }
@@ -55,7 +55,7 @@ struct fx_ptr {
 template<class T>
 struct make {
     template<class... Ts>
-    constexpr auto operator()(Ts&&... xs) const
+    constexpr auto operator()(Ts&&... xs) const noexcept
     {
         return T(xs...);
     }
@@ -73,8 +73,8 @@ struct make_ptr {
 #if BOOST_HOF_HAS_NOEXCEPT_DEDUCTION
 BOOST_HOF_TEST_CASE()
 {
-    static_assert(boost::hof::substitute(
-        make<fx_x_add_n>(), make<fx_x_add_n>(), boost::hof::identity)(3), "noexcept substitute");
+    static_assert(noexcept(boost::hof::substitute(
+        make<fx_x_add_n>(), make<fx_x_add_n>(), boost::hof::identity)(3)), "noexcept substitute");
 }
 #endif 
 

--- a/test/substitute.cpp
+++ b/test/substitute.cpp
@@ -1,0 +1,210 @@
+/*=============================================================================
+    Copyright (c) 2017 Paul Fultz II
+    substitute.cpp
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+==============================================================================*/
+#include <boost/hof/function.hpp>
+#include <boost/hof/lambda.hpp>
+#include <boost/hof/placeholders.hpp>
+#include <boost/hof/substitute.hpp>
+#include "test.hpp"
+
+namespace substitute_test {
+struct fx_x_add_n {
+    int n;
+    constexpr fx_x_add_n(int n) : n(n) {}
+    template<class T>
+    constexpr T operator()(T x) const
+    {
+        return x + n;
+    }
+};
+
+struct fx_x_times_n {
+    int n;
+    constexpr fx_x_times_n(int n) : n(n) {}
+    template<class T>
+    constexpr T operator()(T x) const
+    {
+        return x * n;
+    }
+};
+
+struct fx_n_sub_x {
+    int n;
+    constexpr fx_n_sub_x(int n) : n(n) {}
+    template<class T>
+    constexpr T operator()(T x) const
+    {
+        return n - x;
+    }
+};
+
+template <class F>
+struct fx_ptr {
+    std::unique_ptr<F> f;
+    fx_ptr(int n) : f(new F(n)) {}
+    template <class T>
+    T operator()(T x) const
+    {
+        return (*f)(x);
+    }
+};
+
+template<class T>
+struct make {
+    template<class... Ts>
+    constexpr auto operator()(Ts&&... xs) const
+    {
+        return T(xs...);
+    }
+};
+
+template<class T>
+struct make_ptr {
+    template<class... Ts>
+    constexpr auto operator()(Ts&&... xs) const
+    {
+        return fx_ptr<T>(xs...);
+    }
+};
+
+#if BOOST_HOF_HAS_NOEXCEPT_DEDUCTION
+BOOST_HOF_TEST_CASE()
+{
+    static_assert(boost::hof::substitute(
+        make<fx_x_add_n>(), make<fx_x_add_n>(), boost::hof::identity)(3), "noexcept substitute");
+}
+#endif 
+
+BOOST_HOF_TEST_CASE(){
+    BOOST_HOF_TEST_CHECK(boost::hof::substitute(boost::hof::always)(3)() == 3);
+    BOOST_HOF_TEST_CHECK(boost::hof::substitute(boost::hof::always, boost::hof::always)(3) == 3);
+    BOOST_HOF_TEST_CHECK(boost::hof::substitute(boost::hof::always, boost::hof::always, boost::hof::always)(3) == 3);
+
+    BOOST_HOF_STATIC_TEST_CHECK(boost::hof::substitute(boost::hof::always)(3)() == 3);
+    BOOST_HOF_STATIC_TEST_CHECK(boost::hof::substitute(boost::hof::always, boost::hof::always)(3) == 3);
+    BOOST_HOF_STATIC_TEST_CHECK(boost::hof::substitute(boost::hof::always, boost::hof::always, boost::hof::always)(3) == 3);
+}
+
+BOOST_HOF_TEST_CASE()
+{
+    int r = boost::hof::substitute(make<fx_x_add_n>(), make<fx_x_add_n>(), boost::hof::identity)(3);
+    BOOST_HOF_TEST_CHECK(r == 9);
+    BOOST_HOF_STATIC_TEST_CHECK(boost::hof::substitute(
+        make<fx_x_add_n>(), make<fx_x_add_n>(), boost::hof::identity)(3) == 9);
+}
+
+BOOST_HOF_TEST_CASE()
+{
+    int r = boost::hof::substitute(make<fx_x_add_n>(), make<fx_n_sub_x>(), make<fx_x_times_n>(), boost::hof::identity)(3);
+    BOOST_HOF_TEST_CHECK(r == -3);
+    BOOST_HOF_STATIC_TEST_CHECK(boost::hof::substitute(
+        make<fx_x_add_n>(), make<fx_n_sub_x>(), make<fx_x_times_n>(), boost::hof::identity)(3) == -3);
+}
+
+BOOST_HOF_TEST_CASE()
+{
+    constexpr auto f = boost::hof::substitute(make<fx_x_add_n>(), boost::hof::identity);
+#ifndef _MSC_VER
+    static_assert(std::is_empty<decltype(f)>::value, "Substitute function not empty");
+#endif
+    static_assert(BOOST_HOF_IS_DEFAULT_CONSTRUCTIBLE(decltype(f)), "Substitute function not default constructible");
+    int r = f(3);
+    BOOST_HOF_TEST_CHECK(r == 6);
+    BOOST_HOF_STATIC_TEST_CHECK(f(3) == 6);
+}
+
+#ifndef _MSC_VER
+BOOST_HOF_TEST_CASE()
+{
+    constexpr auto f = boost::hof::substitute(make<fx_x_add_n>(), make<fx_n_sub_x>(), make<fx_x_times_n>(), boost::hof::identity);
+    static_assert(std::is_empty<decltype(f)>::value, "Substitute function not empty");
+    static_assert(BOOST_HOF_IS_DEFAULT_CONSTRUCTIBLE(decltype(f)), "Substitute function not default constructible");
+    int r = f(3);
+    BOOST_HOF_TEST_CHECK(r == -3);
+    BOOST_HOF_STATIC_TEST_CHECK(f(3) == -3);
+}
+#endif
+
+BOOST_HOF_TEST_CASE()
+{
+    STATIC_ASSERT_MOVE_ONLY(fx_ptr<fx_x_add_n>);
+    STATIC_ASSERT_MOVE_ONLY(fx_ptr<fx_n_sub_x>);
+    STATIC_ASSERT_MOVE_ONLY(fx_ptr<fx_x_times_n>);
+    int r = boost::hof::substitute(
+        make_ptr<fx_x_add_n>(), make_ptr<fx_n_sub_x>(), make_ptr<fx_x_times_n>(), boost::hof::identity)(3);
+    BOOST_HOF_TEST_CHECK(r == -3);
+}
+
+BOOST_HOF_TEST_CASE()
+{
+    auto make_lambda_add = [](int n) { 
+        return [n](int x) { return x + n; };
+    };
+    auto make_lambda_times = [](int n) { 
+        return [n](int x) { return x * n; };
+    };
+    {
+        const auto f = boost::hof::substitute(
+            make_lambda_add,
+            make_lambda_times,
+            [](int i) { return i+1; }
+        );
+#ifndef _MSC_VER
+        static_assert(std::is_empty<decltype(f)>::value, "Substitute function not empty");
+#endif
+        int r = f(3);
+        BOOST_HOF_TEST_CHECK(r == 15);
+    }
+    {
+        BOOST_HOF_STATIC_LAMBDA_FUNCTION(f_substitute_lambda) = boost::hof::substitute(
+            make_lambda_add, 
+            make_lambda_times, 
+            [](int i) { return i+1; }
+        );
+        int r = f_substitute_lambda(3);
+        BOOST_HOF_TEST_CHECK(r == 15);
+    }
+}
+
+BOOST_HOF_STATIC_FUNCTION(f_substitute_single_function) = boost::hof::substitute(fx_x_add_n(1));
+BOOST_HOF_TEST_CASE()
+{
+    BOOST_HOF_TEST_CHECK(f_substitute_single_function(3) == 4);
+    BOOST_HOF_STATIC_TEST_CHECK(f_substitute_single_function(3) == 4);
+}
+
+BOOST_HOF_STATIC_FUNCTION(f_substitute_function) = boost::hof::substitute(
+    make<fx_x_add_n>(), make<fx_x_times_n>(), boost::hof::identity);
+BOOST_HOF_TEST_CASE()
+{
+    BOOST_HOF_TEST_CHECK(f_substitute_function(3) == 12);
+    BOOST_HOF_STATIC_TEST_CHECK(f_substitute_function(3) == 12);
+}
+
+BOOST_HOF_STATIC_FUNCTION(f_substitute_function_4) = boost::hof::substitute(
+    make<fx_x_add_n>(), make<fx_n_sub_x>(), make<fx_x_times_n>(), boost::hof::identity
+);
+BOOST_HOF_TEST_CASE()
+{
+    BOOST_HOF_TEST_CHECK(f_substitute_function_4(3) == -3);
+    BOOST_HOF_STATIC_TEST_CHECK(f_substitute_function_4(3) == -3);
+}
+
+BOOST_HOF_TEST_CASE()
+{
+    BOOST_HOF_TEST_CHECK(boost::hof::substitute(
+        [](auto x) { return boost::hof::_1 * boost::hof::_1; },
+        [](auto x) { return boost::hof::_1 + boost::hof::_1; },
+        boost::hof::identity
+        )(3) == 36);
+
+    BOOST_HOF_STATIC_TEST_CHECK(boost::hof::substitute(
+        [](auto x) { return boost::hof::_1 * boost::hof::_1; },
+        [](auto x) { return boost::hof::_1 + boost::hof::_1; },
+        boost::hof::identity
+        )(3) == 36);
+}
+}  // namespace substitute_test

--- a/test/substitute.cpp
+++ b/test/substitute.cpp
@@ -169,11 +169,11 @@ BOOST_HOF_TEST_CASE()
     }
 }
 
-BOOST_HOF_STATIC_FUNCTION(f_substitute_single_function) = boost::hof::substitute(fx_x_add_n(1));
+BOOST_HOF_STATIC_FUNCTION(f_substitute_single_function) = boost::hof::substitute(boost::hof::identity);
 BOOST_HOF_TEST_CASE()
 {
-    BOOST_HOF_TEST_CHECK(f_substitute_single_function(3) == 4);
-    BOOST_HOF_STATIC_TEST_CHECK(f_substitute_single_function(3) == 4);
+    BOOST_HOF_TEST_CHECK(f_substitute_single_function(3) == 3);
+    BOOST_HOF_STATIC_TEST_CHECK(f_substitute_single_function(3) == 3);
 }
 
 BOOST_HOF_STATIC_FUNCTION(f_substitute_function) = boost::hof::substitute(
@@ -191,20 +191,5 @@ BOOST_HOF_TEST_CASE()
 {
     BOOST_HOF_TEST_CHECK(f_substitute_function_4(3) == -3);
     BOOST_HOF_STATIC_TEST_CHECK(f_substitute_function_4(3) == -3);
-}
-
-BOOST_HOF_TEST_CASE()
-{
-    BOOST_HOF_TEST_CHECK(boost::hof::substitute(
-        [](auto x) { return boost::hof::_1 * boost::hof::_1; },
-        [](auto x) { return boost::hof::_1 + boost::hof::_1; },
-        boost::hof::identity
-        )(3) == 36);
-
-    BOOST_HOF_STATIC_TEST_CHECK(boost::hof::substitute(
-        [](auto x) { return boost::hof::_1 * boost::hof::_1; },
-        [](auto x) { return boost::hof::_1 + boost::hof::_1; },
-        boost::hof::identity
-        )(3) == 36);
 }
 }  // namespace substitute_test


### PR DESCRIPTION
I added the substitute combinator as described in #192. 

The implementation is nearly identical to the implementation of compose/flow. I tried a few times to have them share code, but I ran into various template parameter problems.

Lines 61 and 74 of the `substitute.hpp` file are commented out. They don't appear to be necessary, but are present in the compose/flow files. I think I should either leave them it, or remove them from all the files. I'm not sure which.