### PR TITLE
Add modular library level build file.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/hof

--- a/build.jam
+++ b/build.jam
@@ -11,9 +11,10 @@ project /boost/hof
     ;
 
 explicit
-    [ alias boost_hof ]
+    [ alias boost_hof : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_hof test ]
     ;
 
 call-if : boost-library hof
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/hof
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,19 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/hof
+    : common-requirements
+        <include>include
+    ;
+
+explicit
+    [ alias boost_hof ]
+    [ alias all : boost_hof test ]
+    ;
+
+call-if : boost-library hof
+    ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -4,12 +4,14 @@
 #    Distributed under the Boost Software License, Version 1.0. (See accompanying
 #    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #==============================================================================
+
+import-search /boost/config/checks ;
+
 import testing ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 project hof
     : requirements [ requires cxx11_variadic_templates cxx11_constexpr ]
-      <include>../include/ 
     ;
 
 rule test_all


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.